### PR TITLE
Add documentation to graft-tracing crate

### DIFF
--- a/crates/graft-tracing/src/lib.rs
+++ b/crates/graft-tracing/src/lib.rs
@@ -1,3 +1,9 @@
+//! Tracing utilities for the Graft project.
+//!
+//! This crate provides functionality for initializing and configuring tracing
+//! in different environments (test, server, tool) with customizable output formats.
+//! It supports different timestamp formats and process identification for distributed tracing.
+
 use parking_lot::Once;
 use std::time::Instant;
 use tracing_subscriber::{
@@ -14,22 +20,51 @@ use tracing_subscriber::{
     },
 };
 
+/// Checks if the application is running in the Antithesis testing environment.
+///
+/// Returns `true` if the ANTITHESIS_OUTPUT_DIR environment variable is set.
 pub fn running_in_antithesis() -> bool {
     std::env::var("ANTITHESIS_OUTPUT_DIR").is_ok()
 }
 
+/// Specifies the type of application consuming the tracing output.
+///
+/// Used to configure appropriate tracing settings for different contexts.
 #[derive(PartialEq, Eq)]
 pub enum TracingConsumer {
+    /// Test environment consumer
     Test,
+    /// Server application consumer
     Server,
+    /// Command-line tool consumer
     Tool,
 }
 
+/// Initializes tracing with stdout as the output.
+///
+/// This is a convenience wrapper around `init_tracing_with_writer` that uses
+/// standard output as the writer.
+///
+/// # Parameters
+/// * `consumer` - The type of application consuming the tracing output
+/// * `process_id` - Optional identifier for the process, randomly generated if None
 pub fn init_tracing(consumer: TracingConsumer, process_id: Option<String>) {
     init_tracing_with_writer(consumer, process_id, std::io::stdout);
 }
 
-/// Initialize tracing. If no `process_id` is specified one will be randomly generated.
+/// Initializes tracing with a custom writer for output.
+///
+/// Sets up a tracing subscriber with configuration based on the consumer type
+/// and environment. This function will only initialize tracing once, even if
+/// called multiple times.
+///
+/// # Parameters
+/// * `consumer` - The type of application consuming the tracing output
+/// * `process_id` - Optional identifier for the process, randomly generated if None
+/// * `writer` - Custom writer implementation for tracing output
+///
+/// # Type Parameters
+/// * `W` - Writer type that implements the MakeWriter trait
 pub fn init_tracing_with_writer<W>(consumer: TracingConsumer, process_id: Option<String>, writer: W)
 where
     W: for<'writer> MakeWriter<'writer> + 'static + Send + Sync,
@@ -93,22 +128,46 @@ where
     });
 }
 
+/// Defines the format for timestamps in trace output.
 enum TimeFormat {
+    /// No timestamp output
     None,
+    /// Full system time format
     Long(SystemTime),
+    /// Time elapsed since a specific starting point
     Offset { start: Instant },
 }
 
+/// Combines a process identifier prefix with timestamp formatting.
+///
+/// Used to customize the time format in trace output, optionally including
+/// a process identifier prefix.
 struct TimeAndPrefix {
+    /// Optional process identifier to include in trace output
     prefix: Option<String>,
+    /// Time format specification
     time: TimeFormat,
 }
 
 impl TimeAndPrefix {
+    /// Creates a new TimeAndPrefix instance.
+    ///
+    /// # Parameters
+    /// * `prefix` - Optional process identifier to include in trace output
+    /// * `time` - Time format specification
     fn new(prefix: Option<String>, time: TimeFormat) -> Self {
         Self { prefix, time }
     }
 
+    /// Writes the time component to the output writer.
+    ///
+    /// Formats the time according to the configured TimeFormat.
+    ///
+    /// # Parameters
+    /// * `w` - Writer to output the formatted time
+    ///
+    /// # Returns
+    /// Result indicating success or failure of the write operation
     fn write_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
         match self.time {
             TimeFormat::None => Ok(()),
@@ -124,7 +183,18 @@ impl TimeAndPrefix {
     }
 }
 
+/// Implementation of FormatTime for TimeAndPrefix.
 impl FormatTime for TimeAndPrefix {
+    /// Formats the time with an optional prefix for trace output.
+    ///
+    /// Combines the process identifier prefix (if present) with the
+    /// formatted time according to the configured TimeFormat.
+    ///
+    /// # Parameters
+    /// * `w` - Writer to output the formatted time
+    ///
+    /// # Returns
+    /// Result indicating success or failure of the write operation
     fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
         match (&self.prefix, &self.time) {
             (None, _) => self.write_time(w),


### PR DESCRIPTION
This PR adds rustdoc documentation to all public methods and types in the graft-tracing crate. The documentation follows rustdoc specifications and provides clear, concise descriptions of the functionality without including doc tests.