### PR TITLE
Feat cheaper polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ name = "graft-server"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "async-trait",
  "axum",
  "axum-test",
  "bytes",
@@ -1299,6 +1300,7 @@ dependencies = [
  "graft-tracing",
  "hashbrown 0.15.2",
  "http",
+ "itertools 0.14.0",
  "lsm-tree",
  "measured",
  "memmap2",
@@ -1306,6 +1308,7 @@ dependencies = [
  "precept",
  "prost",
  "prost-types",
+ "rand 0.9.0",
  "rlimit",
  "rusty_paseto",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
+async-trait = "0.1.88"
 hex = "0.4"
 rusty_paseto = "0.7.2"
 platform-dirs = "0.3.0"

--- a/crates/graft-server/Cargo.toml
+++ b/crates/graft-server/Cargo.toml
@@ -23,6 +23,7 @@ precept = { workspace = true, features = ["antithesis"] }
 event-listener = { workspace = true }
 culprit = { workspace = true }
 tryiter = { workspace = true }
+itertools = { workspace = true }
 tokio = { workspace = true, features = [
   "bytes",
   "rt-multi-thread",
@@ -65,3 +66,5 @@ toml = { workspace = true }
 graft-core = { path = "../graft-core", features = ["testutil"] }
 graft-test = { path = "../graft-test" }
 axum-test = { workspace = true }
+async-trait = { workspace = true }
+rand = { workspace = true }

--- a/crates/graft-server/src/api/metastore/commit.rs
+++ b/crates/graft-server/src/api/metastore/commit.rs
@@ -257,7 +257,7 @@ mod tests {
             }
 
             // check the commit in the store and the catalog
-            let commit = store.get_commit(vid.clone(), lsn).await.unwrap();
+            let commit = store.get_commit(&vid, lsn).await.unwrap().unwrap();
             assert_eq!(commit.meta().lsn(), lsn);
 
             let snapshot = catalog.latest_snapshot(&vid).unwrap().unwrap();

--- a/crates/graft-server/src/api/metastore/pull_graft.rs
+++ b/crates/graft-server/src/api/metastore/pull_graft.rs
@@ -103,11 +103,11 @@ mod tests {
     use axum::{handler::Handler, http::StatusCode};
     use axum_test::TestServer;
     use graft_core::{SegmentId, gid::ClientId, lsn::LSN, page_count::PageCount};
-    use object_store::memory::InMemory;
     use prost::Message;
 
     use crate::{
         api::extractors::CONTENT_TYPE_PROTOBUF,
+        testutil::test_object_store::{ObjectStoreOp, TestObjectStore},
         volume::{
             catalog::VolumeCatalog,
             commit::{CommitBuilder, CommitMeta},
@@ -120,8 +120,8 @@ mod tests {
 
     #[graft_test::test]
     async fn test_pull_graft_sanity() {
-        let store = Arc::new(InMemory::default());
-        let store = Arc::new(VolumeStore::new(store));
+        let objstore = Arc::new(TestObjectStore::default());
+        let store = Arc::new(VolumeStore::new(objstore.clone()));
         let catalog = VolumeCatalog::open_temporary().unwrap();
 
         let state = Arc::new(MetastoreApiState::new(
@@ -147,6 +147,10 @@ mod tests {
             .expect_failure()
             .await;
         assert_eq!(resp.status_code(), StatusCode::NOT_FOUND);
+
+        // only one object store request should have been issued
+        assert_eq!(objstore.count_hits(ObjectStoreOp::Get).await, 1);
+        objstore.reset_hits().await;
 
         // case 2: catalog is empty, store has 10 commits
         let graft = Splinter::from_iter([0u32]).serialize_to_bytes();
@@ -186,6 +190,10 @@ mod tests {
         assert_eq!(splinter.cardinality(), 1);
         assert_eq!(splinter.iter().collect::<Vec<_>>(), vec![0]);
 
+        // 11 hits are expected, 10 successes followed by one 404
+        assert_eq!(objstore.count_hits(ObjectStoreOp::Get).await, 11);
+        objstore.reset_hits().await;
+
         // request all the segments
         let req = PullGraftRequest { vid: vid.copy_to_bytes(), range: None };
         let resp = server.post("/").bytes(req.encode_to_vec().into()).await;
@@ -193,5 +201,8 @@ mod tests {
         let splinter = Splinter::from_bytes(resp.graft).unwrap();
         assert_eq!(splinter.cardinality(), 1);
         assert_eq!(splinter.iter().collect::<Vec<_>>(), vec![0]);
+
+        // only one hit is expected to check for new lsns
+        assert_eq!(objstore.count_hits(ObjectStoreOp::Get).await, 1);
     }
 }

--- a/crates/graft-server/src/api/metastore/pull_graft.rs
+++ b/crates/graft-server/src/api/metastore/pull_graft.rs
@@ -63,7 +63,7 @@ pub async fn handler(
         return Err(Culprit::new_with_note(
             ApiErrCtx::SnapshotMissing,
             format!(
-                "volume {vid} snapshot {:?} happens before {start_lsn:?}",
+                "volume {vid} is behind requested snapshot {start_lsn:?}; latest snapshot {:?}",
                 snapshot.lsn()
             ),
         )

--- a/crates/graft-server/src/testutil.rs
+++ b/crates/graft-server/src/testutil.rs
@@ -1,5 +1,7 @@
 use std::{future::Future, time::Duration};
 
+pub mod test_object_store;
+
 pub async fn assert_would_timeout<F, O>(fut: F)
 where
     F: Future<Output = O>,

--- a/crates/graft-server/src/testutil/test_object_store.rs
+++ b/crates/graft-server/src/testutil/test_object_store.rs
@@ -1,0 +1,173 @@
+use std::{
+    fmt::{Debug, Display},
+    ops::Range,
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use foldhash::HashMap;
+use futures::stream::BoxStream;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts,
+    PutOptions, PutPayload, PutResult, Result, memory::InMemory, path::Path,
+};
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ObjectStoreOp {
+    Put,
+    Copy,
+    Rename,
+    Get,
+    Head,
+    Delete,
+    DeleteStream,
+    List,
+}
+
+#[derive(Debug, Default)]
+pub struct TestObjectStore {
+    inner: InMemory,
+    hits: Mutex<HashMap<ObjectStoreOp, usize>>,
+}
+
+impl Display for TestObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self, f)
+    }
+}
+
+impl TestObjectStore {
+    async fn hit(&self, op: ObjectStoreOp) {
+        let mut hits = self.hits.lock().await;
+        *hits.entry(op).or_insert(0) += 1;
+    }
+
+    fn hit_blocking(&self, op: ObjectStoreOp) {
+        let mut hits = self.hits.blocking_lock();
+        *hits.entry(op).or_insert(0) += 1;
+    }
+
+    pub async fn all_hits(&self) -> HashMap<ObjectStoreOp, usize> {
+        self.hits.lock().await.clone()
+    }
+
+    pub async fn count_hits(&self, op: ObjectStoreOp) -> usize {
+        let hits = self.hits.lock().await;
+        *hits.get(&op).unwrap_or(&0)
+    }
+
+    pub async fn reset_hits(&self) {
+        let mut hits = self.hits.lock().await;
+        hits.clear();
+    }
+}
+
+#[async_trait]
+impl ObjectStore for TestObjectStore {
+    async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
+        self.hit(ObjectStoreOp::Put).await;
+        self.inner.put(location, payload).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        self.hit(ObjectStoreOp::Put).await;
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
+        self.hit(ObjectStoreOp::Put).await;
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.hit(ObjectStoreOp::Put).await;
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get(&self, location: &Path) -> Result<GetResult> {
+        self.hit(ObjectStoreOp::Get).await;
+        self.inner.get(location).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.hit(ObjectStoreOp::Get).await;
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
+        self.hit(ObjectStoreOp::Get).await;
+        self.inner.get_range(location, range).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+        self.hit(ObjectStoreOp::Get).await;
+        self.inner.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.hit(ObjectStoreOp::Head).await;
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        self.hit(ObjectStoreOp::Delete).await;
+        self.inner.delete(location).await
+    }
+
+    fn delete_stream<'a>(
+        &'a self,
+        locations: BoxStream<'a, Result<Path>>,
+    ) -> BoxStream<'a, Result<Path>> {
+        self.hit_blocking(ObjectStoreOp::DeleteStream);
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.hit_blocking(ObjectStoreOp::List);
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.hit_blocking(ObjectStoreOp::List);
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.hit(ObjectStoreOp::List).await;
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.hit(ObjectStoreOp::Copy).await;
+        self.inner.copy(from, to).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        self.hit(ObjectStoreOp::Rename).await;
+        self.inner.rename(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.hit(ObjectStoreOp::Copy).await;
+        self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.hit(ObjectStoreOp::Rename).await;
+        self.inner.rename_if_not_exists(from, to).await
+    }
+}

--- a/crates/graft-server/src/volume/store.rs
+++ b/crates/graft-server/src/volume/store.rs
@@ -1,20 +1,24 @@
-use std::{future::ready, ops::RangeBounds, sync::Arc};
+use std::{
+    future::{self},
+    ops::RangeBounds,
+    sync::Arc,
+};
 
 use bytes::Bytes;
 use culprit::{Culprit, ResultExt};
-use futures::{Stream, TryStreamExt, stream::FuturesUnordered};
+use futures::{
+    Stream, StreamExt, TryStreamExt,
+    stream::{self, FuturesOrdered},
+};
 use graft_core::{
     VolumeId,
     lsn::{LSN, LSNRangeExt},
 };
 use object_store::{Attributes, ObjectStore, PutMode, PutOptions, TagSet};
 
-use crate::{
-    bytes_vec::BytesVec,
-    volume::commit::{CommitValidationErr, commit_key_path_prefix},
-};
+use crate::{bytes_vec::BytesVec, volume::commit::CommitValidationErr};
 
-use super::commit::{Commit, CommitKeyParseErr, commit_key_path, parse_commit_key};
+use super::commit::{Commit, CommitKeyParseErr, commit_key_path};
 
 const REPLAY_CONCURRENCY: usize = 5;
 
@@ -22,6 +26,9 @@ const REPLAY_CONCURRENCY: usize = 5;
 pub enum VolumeStoreErr {
     #[error("object store error")]
     ObjectStoreErr,
+
+    #[error("commit not found")]
+    CommitNotFound,
 
     #[error("commit already exists")]
     CommitAlreadyExists,
@@ -36,6 +43,7 @@ pub enum VolumeStoreErr {
 impl From<object_store::Error> for VolumeStoreErr {
     fn from(err: object_store::Error) -> Self {
         match err {
+            object_store::Error::NotFound { .. } => VolumeStoreErr::CommitNotFound,
             object_store::Error::AlreadyExists { .. } => VolumeStoreErr::CommitAlreadyExists,
             _ => VolumeStoreErr::ObjectStoreErr,
         }
@@ -69,51 +77,130 @@ impl VolumeStore {
     }
 
     /// Replay all commits for a volume contained by the specified LSN range.
-    pub fn replay_unordered<'a, R: RangeBounds<LSN> + 'a>(
+    pub fn replay_ordered<'a, R: RangeBounds<LSN> + 'a>(
         &'a self,
-        vid: VolumeId,
+        vid: &'a VolumeId,
         range: &'a R,
     ) -> impl Stream<Item = Result<Commit<Bytes>, Culprit<VolumeStoreErr>>> + 'a {
-        let stream = if let Some(from_lsn) = range.try_start_exclusive() {
-            self.store.list_with_offset(
-                Some(&commit_key_path_prefix(&vid)),
-                &commit_key_path(&vid, from_lsn),
-            )
-        } else {
-            self.store.list(Some(&commit_key_path_prefix(&vid)))
-        };
+        // convert the range into a stream of chunks, such that the first chunk
+        // only contains the first LSN, and the remaining chunks have a maximum
+        // size of REPLAY_CONCURRENCY
+        let mut iter = range.iter();
+        let first_chunk: Vec<LSN> = iter.next().into_iter().collect();
+        let chunks = stream::once(future::ready(first_chunk))
+            .chain(stream::iter(iter).chunks(REPLAY_CONCURRENCY));
 
-        stream
-            .err_into()
-            // We can't use try_take_while because we can't depend on the object
-            // store implementation to return keys sorted alphanumerically.
-            .try_filter_map(move |meta| {
-                let (key_vid, lsn) = match parse_commit_key(&meta.location).or_into_ctx() {
-                    Ok((vid, lsn)) => (vid, lsn),
-                    Err(err) => return ready(Err(err)),
-                };
-                assert!(vid == key_vid, "Unexpected volume ID in commit key");
-                ready(Ok(range.contains(&lsn).then_some((key_vid, lsn))))
-            })
-            .try_ready_chunks(REPLAY_CONCURRENCY)
-            .map_ok(|chunk| {
+        chunks
+            .flat_map(move |chunk| {
                 chunk
                     .into_iter()
-                    .map(|(vid, lsn)| self.get_commit(vid, lsn))
-                    .collect::<FuturesUnordered<_>>()
+                    .map(|lsn| self.get_commit(vid, lsn))
+                    .collect::<FuturesOrdered<_>>()
             })
-            .map_err(|err| err.1)
-            .try_flatten()
+            .try_take_while(|result| future::ready(Ok(result.is_some())))
+            .map_ok(|result| result.unwrap())
     }
 
     pub async fn get_commit(
         &self,
-        vid: VolumeId,
+        vid: &VolumeId,
         lsn: LSN,
-    ) -> Result<Commit<Bytes>, Culprit<VolumeStoreErr>> {
-        let path = commit_key_path(&vid, lsn);
-        let commit = self.store.get(&path).await?;
-        let data = commit.bytes().await?;
-        Commit::from_bytes(data).or_into_ctx()
+    ) -> Result<Option<Commit<Bytes>>, Culprit<VolumeStoreErr>> {
+        // inject a random sleep when testing to verify replay_ordered will
+        // correctly reorder futures when they come back out of order. Due to
+        // tokio time mocking this shouldn't actually make the tests slower. We
+        // set the sleep extremely high to make it obvious if tokio time mocking
+        // is not working correctly.
+        #[cfg(test)]
+        {
+            use std::time::Duration;
+            // smaller lsns = larger sleeps
+            let duration = Duration::from_millis(100000 - u64::from(lsn));
+            tokio::time::sleep(duration).await;
+        }
+
+        let path = commit_key_path(vid, lsn);
+        match self.store.get(&path).await {
+            Ok(res) => Commit::from_bytes(res.bytes().await?)
+                .or_into_ctx()
+                .map(Some),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use graft_core::{ClientId, PageCount, lsn::LSN};
+
+    use crate::{
+        testutil::test_object_store::{ObjectStoreOp, TestObjectStore},
+        volume::commit::{CommitBuilder, CommitMeta},
+    };
+
+    use super::*;
+
+    #[graft_test::test]
+    async fn test_replay() {
+        let objstore = Arc::new(TestObjectStore::default());
+        let volstore = VolumeStore::new(objstore.clone());
+
+        let vid = VolumeId::random();
+        let cid = ClientId::random();
+
+        // create some commits
+        let commits = (1..13)
+            .map(|i| LSN::new(i))
+            .map(|lsn| {
+                CommitMeta::new(
+                    vid.clone(),
+                    cid.clone(),
+                    lsn,
+                    LSN::new(1),
+                    PageCount::new(1),
+                    SystemTime::now(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        for meta in commits.iter().cloned() {
+            let commit = CommitBuilder::new_with_capacity(meta, 0).build();
+            volstore.commit(commit).await.unwrap();
+        }
+
+        // verify that we can replay commits, and the result is ordered, and the
+        // expected number of requests were issued
+        let start_lsn = LSN::new(1);
+        let lsns = start_lsn..;
+        let replay = volstore.replay_ordered(&vid, &lsns);
+
+        // zip the replay with the expected commits
+        let mut zipped = replay.zip(futures::stream::iter(commits.clone()));
+
+        let mut count = 0;
+        while let Some((result, expected)) = zipped.next().await {
+            let commit = result.unwrap();
+            assert_eq!(commit.meta(), &expected);
+            count += 1;
+
+            assert!(objstore.count_hits(ObjectStoreOp::Get).await >= count);
+        }
+
+        // verify that we got the expected number of commits
+        assert_eq!(count, commits.len());
+
+        // we expect the object store to receive 16 gets
+        // there are 12 commits in the store (lsns: 1..=12)
+        // replay concurrency is 5; but we always request the first LSN before checking any additional LSNs
+        // so the request batches are: 1, 5, 5, 5
+        assert_eq!(
+            objstore.count_hits(ObjectStoreOp::Get).await,
+            1 + (((commits.len() / REPLAY_CONCURRENCY) + 1) * REPLAY_CONCURRENCY)
+        );
+        // and no list ops were used
+        assert_eq!(objstore.count_hits(ObjectStoreOp::List).await, 0);
     }
 }

--- a/crates/graft-server/src/volume/updater.rs
+++ b/crates/graft-server/src/volume/updater.rs
@@ -165,7 +165,7 @@ impl VolumeCatalogUpdater {
         vid: &VolumeId,
         lsns: &R,
     ) -> Result<(), Culprit<UpdateErr>> {
-        let mut commits = store.replay_unordered(vid.clone(), lsns);
+        let mut commits = store.replay_ordered(vid, lsns);
 
         let mut latest_lsn = lsns.try_start();
         if let Some(commit) = commits.try_next().await.or_into_ctx()? {


### PR DESCRIPTION
Switch from a list operation followed by a set of parallel gets, to
simply a series of batched get operations. We also start by just
requesting the earliest LSN to short circuit `pull_graft` if we already
have the latest LSN.

fixes https://github.com/orbitinghail/graft/issues/47