### PR TITLE
implement graft_pull to fix sqlite_sanity test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -160,4 +160,4 @@ jobs:
           description: "github actions: ${{ github.sha }}: ${{ steps.commit_summary.outputs.COMMIT_SUMMARY }}"
           email_recipients: antithesis-results@orbitinghail.dev
           additional_parameters: |-
-            antithesis.duration=${{inputs.duration || 300}}
+            antithesis.duration=${{inputs.duration || 420}}

--- a/crates/graft-client/src/oracle.rs
+++ b/crates/graft-client/src/oracle.rs
@@ -37,7 +37,7 @@ impl Oracle for NoopOracle {
 /// USENIX Association, USA.
 ///
 /// [1]: https://www.usenix.org/system/files/atc20-maruf.pdf
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LeapOracle {
     /// the last observed read
     last_read: PageIdx,

--- a/crates/graft-client/src/runtime/storage/memtable.rs
+++ b/crates/graft-client/src/runtime/storage/memtable.rs
@@ -28,6 +28,10 @@ impl Memtable {
     pub fn get(&self, pageidx: PageIdx) -> Option<&Page> {
         self.pages.get(&pageidx)
     }
+
+    pub fn contains(&self, pageidx: PageIdx) -> bool {
+        self.pages.contains_key(&pageidx)
+    }
 }
 
 impl IntoIterator for Memtable {

--- a/crates/graft-client/src/runtime/storage/page.rs
+++ b/crates/graft-client/src/runtime/storage/page.rs
@@ -168,3 +168,15 @@ impl From<Page> for PageValue {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PageStatus {
+    /// The page is not available locally
+    Pending,
+    /// The page is empty
+    Empty(Option<LSN>),
+    /// The page is available locally
+    Available(LSN),
+    /// The page is dirty
+    Dirty,
+}

--- a/crates/graft-client/src/runtime/volume_reader.rs
+++ b/crates/graft-client/src/runtime/volume_reader.rs
@@ -137,7 +137,7 @@ fn fetch_page<O: Oracle>(
     local_lsn: LSN,
     pageidx: PageIdx,
 ) -> Result<Page, ClientErr> {
-    let span = tracing::debug_span!(
+    let span = tracing::trace_span!(
         "fetching page from pagestore",
         ?vid,
         %remote_lsn,

--- a/crates/graft-client/src/runtime/volume_writer.rs
+++ b/crates/graft-client/src/runtime/volume_writer.rs
@@ -4,7 +4,7 @@ use graft_core::{PageIdx, VolumeId, page::Page, page_count::PageCount};
 use crate::{ClientErr, oracle::Oracle};
 
 use super::{
-    storage::{memtable::Memtable, snapshot::Snapshot},
+    storage::{memtable::Memtable, page::PageStatus, snapshot::Snapshot},
     volume_reader::{VolumeRead, VolumeReader},
 };
 
@@ -65,6 +65,14 @@ impl VolumeRead for VolumeWriter {
             return Ok(page.clone());
         }
         self.reader.read(oracle, pageidx)
+    }
+
+    /// Read a page's status; supports read your own writes (RYOW)
+    fn status(&self, pageidx: PageIdx) -> Result<PageStatus, ClientErr> {
+        if self.memtable.contains(pageidx) {
+            return Ok(PageStatus::Dirty);
+        }
+        self.reader.status(pageidx)
     }
 }
 

--- a/crates/graft-sqlite/src/vfs.rs
+++ b/crates/graft-sqlite/src/vfs.rs
@@ -253,7 +253,7 @@ impl Vfs for GraftVfs {
                     if vol_file.opts().delete_on_close() {
                         // TODO: do we want to actually delete volumes? or mark them for deletion?
                         self.runtime
-                            .update_volume_config(vol_file.handle().vid(), |conf| {
+                            .update_volume_config(vol_file.vid(), |conf| {
                                 conf.with_sync(SyncDirection::Disabled)
                             })
                             .or_into_ctx()?;

--- a/crates/graft-test/src/workload/sqlite_sanity.rs
+++ b/crates/graft-test/src/workload/sqlite_sanity.rs
@@ -290,6 +290,13 @@ impl Actions {
                 );
             }
             Actions::IntegrityCheck => {
+                // ensure we have a full copy of the database before running
+                // integrity_check. this is because integrity check swallows IO
+                // errors which prevents us from detecting when Antithesis is
+                // injecting network faults while fetching pages, and retrying
+                // the workload.
+                txn.execute("PRAGMA graft_pull", [])?;
+
                 let mut results: Vec<String> = vec![];
                 txn.pragma_query(None, "integrity_check", |r| {
                     results.push(r.get(0)?);

--- a/docs/src/content/docs/docs/sqlite/pragmas.md
+++ b/docs/src/content/docs/docs/sqlite/pragmas.md
@@ -17,7 +17,11 @@ Returns a compressed description of the current connections Snapshot.
 
 #### **`pragma graft_pages`**
 
-Reports the version and cache status of every page accessible by the current connection's Snapshot.
+Reports the status of every page accessible by the current connection's Snapshot.
+
+#### **`pragma graft_pull`**
+
+Pulls every page accessible by the current connectin's Snapshot from the server.
 
 #### **`pragma graft_sync = true|false`**
 

--- a/docs/src/content/docs/docs/sqlite/pragmas.md
+++ b/docs/src/content/docs/docs/sqlite/pragmas.md
@@ -21,7 +21,7 @@ Reports the status of every page accessible by the current connection's Snapshot
 
 #### **`pragma graft_pull`**
 
-Pulls every page accessible by the current connectin's Snapshot from the server.
+Pulls every page accessible by the current connection's Snapshot from the server.
 
 #### **`pragma graft_sync = true|false`**
 

--- a/tests/sql/test_pragmas.sql
+++ b/tests/sql/test_pragmas.sql
@@ -1,0 +1,58 @@
+-- initialize two connections to the same database
+.connection 0
+.open file:Gonv3h382yN51uu51uyaj9?vfs=graft
+pragma graft_status;
+
+.connection 1
+.open file:Gonv3h382yN51uu51uyaj9?vfs=graft
+pragma graft_status;
+
+-- initialize the db on connection 0
+.connection 0
+.echo off
+.read datasets/bank.sql
+.echo on
+
+-- check pragmas
+pragma graft_status;
+pragma graft_snapshot;
+pragma graft_pages;
+pragma graft_pull;
+pragma graft_sync=false;
+pragma graft_sync_errors;
+pragma graft_reset;
+pragma graft_version;
+
+-- check pragmas on connection 1
+.connection 1
+pragma graft_status;
+pragma graft_snapshot;
+pragma graft_pages;
+pragma graft_pull;
+pragma graft_sync=false;
+pragma graft_sync_errors;
+pragma graft_reset;
+pragma graft_version;
+
+-- open a snapshot on connection 1
+begin;
+select count(*) from ledger;
+pragma graft_snapshot;
+
+-- switch to connection 0, write something, check snapshot, switch back
+.connection 0
+INSERT INTO ledger (account_id, amount) VALUES (1, -10), (2, 10);
+pragma graft_snapshot;
+.connection 1
+
+-- check that connection 1 pragmas can't see the new snapshot
+pragma graft_status;
+pragma graft_snapshot;
+pragma graft_pages;
+
+-- close the snapshot and check that we can see the latest snapshot
+commit;
+
+pragma graft_status;
+pragma graft_snapshot;
+pragma graft_pages;

--- a/tests/sql/test_pragmas.sql
+++ b/tests/sql/test_pragmas.sql
@@ -18,10 +18,6 @@ pragma graft_status;
 pragma graft_snapshot;
 pragma graft_pages;
 pragma graft_pull;
-pragma graft_sync=false;
-pragma graft_sync_errors;
-pragma graft_reset;
-pragma graft_version;
 
 -- check pragmas on connection 1
 .connection 1
@@ -29,10 +25,6 @@ pragma graft_status;
 pragma graft_snapshot;
 pragma graft_pages;
 pragma graft_pull;
-pragma graft_sync=false;
-pragma graft_sync_errors;
-pragma graft_reset;
-pragma graft_version;
 
 -- open a snapshot on connection 1
 begin;

--- a/tests/sql/test_pragmas.sql.expected
+++ b/tests/sql/test_pragmas.sql.expected
@@ -1,0 +1,249 @@
+-- initialize two connections to the same database
+.connection 0
+.open file:Gonv3h382yN51uu51uyaj9?vfs=graft
+pragma graft_status;
++-----------------------------------+
+|           Graft Status            |
++-----------------------------------+
+| Graft Status                      |
+| Client ID: QiAaT13YZ7eaoi5HHq8hKM |
+| Volume ID: Gonv3h382yN51uu51uyaj9 |
+| Current snapshot: None            |
+| Autosync: false                   |
+| Volume status: Ok                 |
++-----------------------------------+
+
+.connection 1
+.open file:Gonv3h382yN51uu51uyaj9?vfs=graft
+pragma graft_status;
++-----------------------------------+
+|           Graft Status            |
++-----------------------------------+
+| Graft Status                      |
+| Client ID: QiAaT13YZ7eaoi5HHq8hKM |
+| Volume ID: Gonv3h382yN51uu51uyaj9 |
+| Current snapshot: None            |
+| Autosync: false                   |
+| Volume status: Ok                 |
++-----------------------------------+
+
+-- initialize the db on connection 0
+.connection 0
+.echo off
+
+-- check pragmas
+pragma graft_status;
++-----------------------------------+
+|           Graft Status            |
++-----------------------------------+
+| Graft Status                      |
+| Client ID: QiAaT13YZ7eaoi5HHq8hKM |
+| Volume ID: Gonv3h382yN51uu51uyaj9 |
+| Current snapshot: Snapshot[6;14]  |
+| Autosync: false                   |
+| Volume status: Ok                 |
++-----------------------------------+
+pragma graft_snapshot;
++----------------+
+| Snapshot[6;14] |
++----------------+
+| Snapshot[6;14] |
++----------------+
+pragma graft_pages;
++-------------------------------+
+|   pageno   | lsn    | state   |
++-------------------------------+
+| pageno   | lsn    | state     |
+| 1        | 6      | available |
+| 2        | 6      | available |
+| 3        | 6      | available |
+| 4        | 6      | available |
+| 5        | 6      | available |
+| 6        | 6      | available |
+| 7        | 6      | available |
+| 8        | 6      | available |
+| 9        | 6      | available |
+| 10       | 6      | available |
+| 11       | 6      | available |
+| 12       | 6      | available |
+| 13       | 6      | available |
+| 14       | 6      | available |
++-------------------------------+
+pragma graft_pull;
+pragma graft_sync=false;
+pragma graft_sync_errors;
++---------------------+
+| Recent sync errors: |
++---------------------+
+| Recent sync errors: |
++---------------------+
+pragma graft_reset;
+pragma graft_version;
++----------------------+
+| Graft Version: 0.1.4 |
++----------------------+
+| Graft Version: 0.1.4 |
++----------------------+
+
+-- check pragmas on connection 1
+.connection 1
+pragma graft_status;
++-----------------------------------+
+|           Graft Status            |
++-----------------------------------+
+| Graft Status                      |
+| Client ID: QiAaT13YZ7eaoi5HHq8hKM |
+| Volume ID: Gonv3h382yN51uu51uyaj9 |
+| Current snapshot: Snapshot[6;14]  |
+| Autosync: false                   |
+| Volume status: Ok                 |
++-----------------------------------+
+pragma graft_snapshot;
++----------------+
+| Snapshot[6;14] |
++----------------+
+| Snapshot[6;14] |
++----------------+
+pragma graft_pages;
++-------------------------------+
+|   pageno   | lsn    | state   |
++-------------------------------+
+| pageno   | lsn    | state     |
+| 1        | 6      | available |
+| 2        | 6      | available |
+| 3        | 6      | available |
+| 4        | 6      | available |
+| 5        | 6      | available |
+| 6        | 6      | available |
+| 7        | 6      | available |
+| 8        | 6      | available |
+| 9        | 6      | available |
+| 10       | 6      | available |
+| 11       | 6      | available |
+| 12       | 6      | available |
+| 13       | 6      | available |
+| 14       | 6      | available |
++-------------------------------+
+pragma graft_pull;
+pragma graft_sync=false;
+pragma graft_sync_errors;
++---------------------+
+| Recent sync errors: |
++---------------------+
+| Recent sync errors: |
++---------------------+
+pragma graft_reset;
+pragma graft_version;
++----------------------+
+| Graft Version: 0.1.4 |
++----------------------+
+| Graft Version: 0.1.4 |
++----------------------+
+
+-- open a snapshot on connection 1
+begin;
+select count(*) from ledger;
++----------+
+| count(*) |
++----------+
+| 1000     |
++----------+
+pragma graft_snapshot;
++----------------+
+| Snapshot[6;14] |
++----------------+
+| Snapshot[6;14] |
++----------------+
+
+-- switch to connection 0, write something, check snapshot, switch back
+.connection 0
+INSERT INTO ledger (account_id, amount) VALUES (1, -10), (2, 10);
+pragma graft_snapshot;
++----------------+
+| Snapshot[7;14] |
++----------------+
+| Snapshot[7;14] |
++----------------+
+.connection 1
+
+-- check that connection 1 pragmas can't see the new snapshot
+pragma graft_status;
++-----------------------------------+
+|           Graft Status            |
++-----------------------------------+
+| Graft Status                      |
+| Client ID: QiAaT13YZ7eaoi5HHq8hKM |
+| Volume ID: Gonv3h382yN51uu51uyaj9 |
+| Current snapshot: Snapshot[6;14]  |
+| Autosync: false                   |
+| Volume status: Ok                 |
++-----------------------------------+
+pragma graft_snapshot;
++----------------+
+| Snapshot[6;14] |
++----------------+
+| Snapshot[6;14] |
++----------------+
+pragma graft_pages;
++-------------------------------+
+|   pageno   | lsn    | state   |
++-------------------------------+
+| pageno   | lsn    | state     |
+| 1        | 6      | available |
+| 2        | 6      | available |
+| 3        | 6      | available |
+| 4        | 6      | available |
+| 5        | 6      | available |
+| 6        | 6      | available |
+| 7        | 6      | available |
+| 8        | 6      | available |
+| 9        | 6      | available |
+| 10       | 6      | available |
+| 11       | 6      | available |
+| 12       | 6      | available |
+| 13       | 6      | available |
+| 14       | 6      | available |
++-------------------------------+
+
+-- close the snapshot and check that we can see the latest snapshot
+commit;
+
+pragma graft_status;
++-----------------------------------+
+|           Graft Status            |
++-----------------------------------+
+| Graft Status                      |
+| Client ID: QiAaT13YZ7eaoi5HHq8hKM |
+| Volume ID: Gonv3h382yN51uu51uyaj9 |
+| Current snapshot: Snapshot[7;14]  |
+| Autosync: false                   |
+| Volume status: Ok                 |
++-----------------------------------+
+pragma graft_snapshot;
++----------------+
+| Snapshot[7;14] |
++----------------+
+| Snapshot[7;14] |
++----------------+
+pragma graft_pages;
++-------------------------------+
+|   pageno   | lsn    | state   |
++-------------------------------+
+| pageno   | lsn    | state     |
+| 1        | 6      | available |
+| 2        | 6      | available |
+| 3        | 6      | available |
+| 4        | 7      | available |
+| 5        | 6      | available |
+| 6        | 7      | available |
+| 7        | 6      | available |
+| 8        | 6      | available |
+| 9        | 6      | available |
+| 10       | 6      | available |
+| 11       | 7      | available |
+| 12       | 6      | available |
+| 13       | 7      | available |
+| 14       | 6      | available |
++-------------------------------+
+
+SQLite Exit Code = 0

--- a/tests/sql/test_pragmas.sql.expected
+++ b/tests/sql/test_pragmas.sql.expected
@@ -70,20 +70,6 @@ pragma graft_pages;
 | 14       | 6      | available |
 +-------------------------------+
 pragma graft_pull;
-pragma graft_sync=false;
-pragma graft_sync_errors;
-+---------------------+
-| Recent sync errors: |
-+---------------------+
-| Recent sync errors: |
-+---------------------+
-pragma graft_reset;
-pragma graft_version;
-+----------------------+
-| Graft Version: 0.1.4 |
-+----------------------+
-| Graft Version: 0.1.4 |
-+----------------------+
 
 -- check pragmas on connection 1
 .connection 1
@@ -125,20 +111,6 @@ pragma graft_pages;
 | 14       | 6      | available |
 +-------------------------------+
 pragma graft_pull;
-pragma graft_sync=false;
-pragma graft_sync_errors;
-+---------------------+
-| Recent sync errors: |
-+---------------------+
-| Recent sync errors: |
-+---------------------+
-pragma graft_reset;
-pragma graft_version;
-+----------------------+
-| Graft Version: 0.1.4 |
-+----------------------+
-| Graft Version: 0.1.4 |
-+----------------------+
 
 -- open a snapshot on connection 1
 begin;


### PR DESCRIPTION
This PR implements a new pragma: `pragma graft_pull` which efficiently pulls all of the pages in the Volume (at the current snapshot). This PR also fixes a bug in `pragma graft_pages` so that it correctly returns the page status of pages in the current snapshot rather than always the latest snapshot.

This PR should fix a bug in the `sqlite_sanity` test workload caused by Antithesis triggering a network failure while an integrity check is running. SQLite masks all errors which occur during the integrity check with a stringified result which makes it impossible for us to detect network errors and restart the workload (as network errors are totally a-ok, we just want to ensure that we eventually converge to a correct state).