### PR TITLE
docs: fix possessive its typos

### DIFF
--- a/docs/src/content/docs/docs/internals/gid.md
+++ b/docs/src/content/docs/docs/internals/gid.md
@@ -29,7 +29,7 @@ GIDs have the following layout:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
-Every GID has a 1 byte prefix which encodes it's type. There are currently three known GID types: Volume, Segment, and Client. The prefix may contain other types or namespace metadata in the future. The highest bit of the prefix is always set to ensure that GIDs bs58 serialize to exactly 22 bytes.
+Every GID has a 1 byte prefix which encodes its type. There are currently three known GID types: Volume, Segment, and Client. The prefix may contain other types or namespace metadata in the future. The highest bit of the prefix is always set to ensure that GIDs bs58 serialize to exactly 22 bytes.
 
 Following the prefix is a 48 bit timestamp encoding milliseconds since the unix epoch and stored in network byte order (MSB first).
 

--- a/docs/src/content/docs/docs/internals/metastore.md
+++ b/docs/src/content/docs/docs/internals/metastore.md
@@ -7,7 +7,7 @@ A service which stores Volume metadata including the log of segments per Volume.
 
 ## Metastore Storage
 
-The Metastore will store it's data in a key value store. For now we will use object storage directly. Each commit to a volume will be a separate file, stored in a way that makes it easy for downstream consumers to quickly get up to date.
+The Metastore will store its data in a key value store. For now we will use object storage directly. Each commit to a volume will be a separate file, stored in a way that makes it easy for downstream consumers to quickly get up to date.
 
 ## Storage Layout
 


### PR DESCRIPTION
## Summary
- fix typos using "it's" in internals docs

## Testing
- `grep -n "it's" docs/src/content/docs/docs/internals/*`