### PR TITLE
fix `just run sqlite test`; make it stricter

### DIFF
--- a/tasks/sqlite/bin
+++ b/tasks/sqlite/bin
@@ -40,19 +40,18 @@ if [ ! -f "${SQLITE_BIN}" ]; then
         tar -C "${SQLITE_DIR}" -xzf "${SQLITE_TAR}"
         rm "${SQLITE_TAR}"
         cd "${SQLITE_DIR}/sqlite-autoconf-${SQLITE_VERSION}"
-        export CFLAGS="
-            -DSQLITE_ENABLE_DBSTAT_VTAB
-            -DSQLITE_ENABLE_BYTECODE_VTAB
-            -DSQLITE_ENABLE_FTS4
-            -DSQLITE_ENABLE_FTS5
-            -DSQLITE_ENABLE_MATH_FUNCTIONS
-            -DSQLITE_THREADSAFE=0
-            -DSQLITE_ENABLE_EXPLAIN_COMMENTS
-            -DHAVE_READLINE
-            -DSQLITE_ENABLE_ATOMIC_WRITE
+        export CFLAGS="\
+            -DSQLITE_ENABLE_DBSTAT_VTAB \
+            -DSQLITE_ENABLE_BYTECODE_VTAB \
+            -DSQLITE_ENABLE_FTS4 \
+            -DSQLITE_ENABLE_FTS5 \
+            -DSQLITE_ENABLE_MATH_FUNCTIONS \
+            -DSQLITE_THREADSAFE=0 \
+            -DSQLITE_ENABLE_EXPLAIN_COMMENTS \
+            -DHAVE_READLINE \
+            -DSQLITE_ENABLE_ATOMIC_WRITE \
         "
         ./configure \
-            --all \
             --with-readline-ldflags="-L/opt/homebrew/opt/readline/lib -lreadline" \
             --with-readline-header="/opt/homebrew/opt/readline/include/readline/readline.h"
         make -j 4

--- a/tasks/sqlite/test
+++ b/tasks/sqlite/test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 GIT_ROOT="$(git rev-parse --show-toplevel)"
 
@@ -69,9 +69,11 @@ for TEST in ${TESTS}; do
     # We add the exit code to the output since SQLite returns the number of
     # errors encountered while executing, and some of the tests want to trigger
     # errors on purpose (thus we can't just fail on non-zero exit code).
+    set +e
     OUTPUT=$(just run sqlite bin "${SQLITE_ARGS[@]}" 2>&1 <"${TEST}")
     EXIT_CODE=$?
     OUTPUT=$(printf "%s\n\n%s\n" "${OUTPUT}" "SQLite Exit Code = ${EXIT_CODE}")
+    set -e
 
     if [ -n "${GRAFT_DATA_DIR}" ] && [ -z "${SKIP_CLEANUP:-}" ]; then
         rm -rf "${GRAFT_DATA_DIR}"


### PR DESCRIPTION
* fix sqlite build

Before this change, the sqlite build would fail with:

    configure: error: unrecognized option: `--all'
    Try `./configure --help' for more information

or:

    configure: WARNING: cache variable ac_cv_env_CFLAGS_value contains a newline

to test, run:

    rm -rf target/sqlite-3440000/ && just run sqlite test

* use set -e everywhere we can, and only disable it where we need to