### PR TITLE
test for lazily pulling in data to satisfy sqlite queries

### DIFF
--- a/crates/graft-client/src/pagestore.rs
+++ b/crates/graft-client/src/pagestore.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use culprit::Culprit;
-use graft_core::{VolumeId, page_count::PageCount};
 use graft_core::lsn::LSN;
+use graft_core::{VolumeId, page_count::PageCount};
 use graft_proto::{
     common::v1::SegmentInfo,
     pagestore::v1::{
@@ -23,8 +23,8 @@ pub struct PagestoreClient {
 
 impl PagestoreClient {
     pub fn new(root: Url, client: NetClient) -> Self {
-        Self { 
-            endpoint: root.into(), 
+        Self {
+            endpoint: root.into(),
             client,
             pages_read_count: AtomicU32::new(0),
         }
@@ -42,15 +42,17 @@ impl PagestoreClient {
             lsn: lsn.into(),
             graft,
         };
-        let result = self.client
+        let result = self
+            .client
             .send::<_, ReadPagesResponse>(uri, req)
             .map(|r| r.pages);
-        
+
         // Increment the counter with the number of pages read
         if let Ok(ref pages) = result {
-            self.pages_read_count.fetch_add(pages.len() as u32, Ordering::Relaxed);
+            self.pages_read_count
+                .fetch_add(pages.len() as u32, Ordering::Relaxed);
         }
-        
+
         result
     }
 

--- a/crates/graft-client/src/runtime/runtime.rs
+++ b/crates/graft-client/src/runtime/runtime.rs
@@ -36,6 +36,10 @@ impl Runtime {
         &self.cid
     }
 
+    pub fn clients(&self) -> &ClientPair {
+        &self.clients
+    }
+
     pub fn start_sync_task(
         &self,
         refresh_interval: Duration,

--- a/crates/graft-test/tests/sqlite.rs
+++ b/crates/graft-test/tests/sqlite.rs
@@ -143,7 +143,11 @@ fn test_sqlite_query_only_fetches_needed_pages() {
     let vid = VolumeId::random();
 
     // create the first node (writer)
-    let writer_runtime = Runtime::new(ClientId::random(), clients.clone(), Storage::open_temporary().unwrap());
+    let writer_runtime = Runtime::new(
+        ClientId::random(),
+        clients.clone(),
+        Storage::open_temporary().unwrap(),
+    );
     writer_runtime
         .start_sync_task(Duration::from_secs(1), 8, true, "sync-1")
         .unwrap();
@@ -186,7 +190,11 @@ fn test_sqlite_query_only_fetches_needed_pages() {
     assert_eq!(writer_handle.snapshot().unwrap().unwrap().pages(), 5);
 
     // create the second node (reader)
-    let reader_runtime = Runtime::new(ClientId::random(), clients.clone(), Storage::open_temporary().unwrap());
+    let reader_runtime = Runtime::new(
+        ClientId::random(),
+        clients.clone(),
+        Storage::open_temporary().unwrap(),
+    );
     reader_runtime
         .start_sync_task(Duration::from_millis(100), 8, true, "sync-2")
         .unwrap();
@@ -215,7 +223,9 @@ fn test_sqlite_query_only_fetches_needed_pages() {
 
     // perform a single row lookup by ID
     let value: i32 = sqlite_reader
-        .query_row("SELECT id FROM test_data WHERE id = 42", [], |row| row.get(0))
+        .query_row("SELECT id FROM test_data WHERE id = 42", [], |row| {
+            row.get(0)
+        })
         .unwrap();
     assert_eq!(value, 42);
     // only a small number of pages are read
@@ -227,11 +237,18 @@ fn test_sqlite_query_only_fetches_needed_pages() {
         .unwrap();
     assert_eq!(value, 5050);
     // this pulls in the rest of the pages
-    assert_eq!(reader_runtime.clients().pagestore().pages_read(), writer_handle.snapshot().unwrap().unwrap().pages());
+    assert_eq!(
+        reader_runtime.clients().pagestore().pages_read(),
+        writer_handle.snapshot().unwrap().unwrap().pages()
+    );
 
     // shutdown everything
-    writer_runtime.shutdown_sync_task(Duration::from_secs(5)).unwrap();
-    reader_runtime.shutdown_sync_task(Duration::from_secs(5)).unwrap();
+    writer_runtime
+        .shutdown_sync_task(Duration::from_secs(5))
+        .unwrap();
+    reader_runtime
+        .shutdown_sync_task(Duration::from_secs(5))
+        .unwrap();
     backend.shutdown(Duration::from_secs(5)).unwrap();
 }
 


### PR DESCRIPTION
* PagestoreClient::pages_read() utilty function to count how many pages are read
* use this utility in existing test_sync_and_reset() test
* new test_sqlite_query_only_fetches_needed_pages() test that makes a medium sized sqlite db (5 pages) and asserts that you only need about half of it before you can perform a single row lookup query.

This is step 1 of my plan from: https://discord.com/channels/1149205110262595634/1369340764743667743/1373677200007499887