### PR TITLE
Add fjall_storage key parsing tests

### DIFF
--- a/crates/graft-kernel/Cargo.toml
+++ b/crates/graft-kernel/Cargo.toml
@@ -28,3 +28,4 @@ bytes = { workspace = true }
 [dev-dependencies]
 graft-core = { path = "../graft-core", features = ["testutil"] }
 graft-test = { path = "../graft-test" }
+assert_matches = { workspace = true }


### PR DESCRIPTION
## Summary
- test roundtrip and invalid parsing for fjall_storage keys
- cover VolumeKey, CommitKey, HandleKey and PageKey

## Testing
- `cargo clippy --all-targets --all-features -q`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_685b57c7cd3483319beb33f55bdf6752